### PR TITLE
Support "~" escapes in ssh.

### DIFF
--- a/ec2
+++ b/ec2
@@ -57,8 +57,8 @@ if echo $chosen | grep -E "ssh:bastion" >/dev/null; then
     fi
     export ip=$priv_ip
     export proxy_command="ssh -i ~/.ssh/$key.pem -W %h:%p $DEFAULT_USER@$bastion_pub_ip"
-    ssh -i ~/.ssh/$key.pem -o ProxyCommand="$proxy_command" $user@$ip
+    exec ssh -i ~/.ssh/$key.pem -o ProxyCommand="$proxy_command" $user@$ip
 else
     export ip=$pub_ip
-    ssh -i ~/.ssh/$key.pem $user@$ip
+    exec ssh -i ~/.ssh/$key.pem $user@$ip
 fi


### PR DESCRIPTION
E.g. `~.` and `~^Z` now works.

Tested manually:
```bash
flutterby:~ ariels$ ec2 ariebach
Welcome to Ubuntu 16.04.3 LTS (GNU/Linux 4.4.0-101-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

8 packages can be updated.
0 updates are security updates.


Last login: Tue Dec  5 12:07:56 2017 from 207.232.46.170
ubuntu@ariels-bach-colossal-bill:~$
ubuntu@ariels-bach-colossal-bill:~$
ubuntu@ariels-bach-colossal-bill:~$ ~^Z [suspend ssh]

[1]+  Stopped                 ec2 ariebach
flutterby:~ ariels$
flutterby:~ ariels$
flutterby:~ ariels$ fg
ec2 ariebach

ubuntu@ariels-bach-colossal-bill:~$
ubuntu@ariels-bach-colossal-bill:~$ logout
Connection to 18.195.139.187 closed.
flutterby:~ ariels$
```